### PR TITLE
Implement high-res mask training with jittered boxes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ tensorboard
 packaging
 timm
 tqdm
+black==23.12.1
+isort==5.12.0
+flake8
+mypy

--- a/train.py
+++ b/train.py
@@ -1,31 +1,33 @@
 # train.py
 
-import argparse
-import json
-import logging
-import traceback
-import os
-import gc
-from pathlib import Path
-
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import autocast, GradScaler
+from torch.cuda.amp import GradScaler, autocast
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
-from torchvision.ops import sigmoid_focal_loss
 from torchvision import transforms as T
-from tqdm import tqdm
+from torchvision.ops import sigmoid_focal_loss
 
 from mobile_sam import sam_model_registry
+
+import argparse
+import gc
+import json
+import logging
+import os
+import traceback
 from finetune_utils.datasets import ComponentDataset
 from finetune_utils.distill_losses import (
-    encoder_matching_loss, decoder_matching_loss,
-    attention_matching_loss, rkd_loss
+    attention_matching_loss,
+    decoder_matching_loss,
+    encoder_matching_loss,
+    rkd_loss,
 )
-from finetune_utils.feature_hooks import register_hooks, pop_features
+from finetune_utils.feature_hooks import pop_features, register_hooks
 from finetune_utils.visualization import overlay_mask_on_image
+from pathlib import Path
+from tqdm import tqdm
 
 # ─────────────────── logging ───────────────────
 logging.basicConfig(
@@ -62,7 +64,9 @@ class WarmupCosineLR(torch.optim.lr_scheduler._LRScheduler):
             return [base_lr * cur / self.warmup for base_lr in self.base_lrs]
         prog = (cur - self.warmup) / max(1, (self.total - self.warmup))
         cos = 0.5 * (1 + np.cos(np.pi * prog))
-        return [base_lr * (self.min_ratio + (1 - self.min_ratio) * cos) for base_lr in self.base_lrs]
+        return [
+            base_lr * (self.min_ratio + (1 - self.min_ratio) * cos) for base_lr in self.base_lrs
+        ]
 
 
 class MemoryEfficientFeatureCache:
@@ -95,8 +99,9 @@ class MemoryEfficientFeatureCache:
 feature_cache = MemoryEfficientFeatureCache()
 
 
-def load_cached_npy_features(base: Path, teacher: str, split: str,
-                             stems: list[str], keys: list[str]):
+def load_cached_npy_features(
+    base: Path, teacher: str, split: str, stems: list[str], keys: list[str]
+):
     feats = []
     for stem in stems:
         this_img = []
@@ -270,7 +275,7 @@ def main():
                 log_gpu_memory(f"Epoch {ep} start (after cache clear)")
 
             student.train()
-            tot_task, tot_dist = 0.0, 0.0
+            tot_task, tot_dist, tot_iou = 0.0, 0.0, 0.0
             pbar = tqdm(tr_loader, desc=f"Train {ep}")
             opt.zero_grad()
 
@@ -282,15 +287,18 @@ def main():
                 dist_loss = torch.tensor(0.0, device=dev)
                 task_loss = torch.tensor(0.0, device=dev)
                 loss = torch.tensor(0.0, device=dev)
-                # 
-                imgs = batch["image"].to(dev)    # [B,3,1024,1024]
-                masks = batch["mask"].to(dev)    # [B,1,1024,1024]
+                #
+                imgs = batch["image"].to(dev)  # [B,3,1024,1024]
+                masks = batch["mask"].to(dev)  # [B,1,1024,1024]
                 ids = batch["id"]
-                osz = batch["original_size"]     # [B, 2] raw sizes
+                osz = batch["original_size"]  # [B, 2] raw sizes
 
                 batched_input = []
                 for i in range(len(imgs)):
-                    entry = { "image": imgs[i], "original_size": (int(osz[i][0]), int(osz[i][1])) }
+                    entry = {
+                        "image": imgs[i],
+                        "original_size": (int(osz[i][0]), int(osz[i][1])),
+                    }
                     if batch["box_prompt"][i] is not None:
                         entry["boxes"] = batch["box_prompt"][i].to(dev).unsqueeze(0)
                     if batch["point_coords"][i] is not None:
@@ -312,28 +320,51 @@ def main():
 
                     batched_input.append(entry)
 
-                with autocast(dtype=torch.bfloat16 if tr_cfg.get("bf16", False) else torch.float16):
-                    out = student(batched_input=batched_input, multimask_output=False)
+                    with autocast(
+                        dtype=torch.bfloat16 if tr_cfg.get("bf16", False) else torch.float16
+                    ):
+                        out = student(batched_input=batched_input, multimask_output=True)
 
-                    low_res_list   = [o["low_res_logits"].squeeze() for o in out]  # [256,256]
-                    low_res_logits = torch.stack(low_res_list, dim=0)              # [B,256,256]
-                    tmp = low_res_logits.unsqueeze(1)                             # [B,1,256,256]
+                        mask_list = []
+                        iou_list = []
+                        for o in out:
+                            mask_up = F.interpolate(
+                                o["masks"].to(torch.float32),
+                                size=masks.shape[-2:],
+                                mode="bilinear",
+                                align_corners=False,
+                            )
+                            mask_list.append(mask_up)
+                            iou_list.append(o["iou_predictions"].to(torch.float32))
 
-                    logit_up = F.interpolate(
-                        tmp,
-                        size=masks.shape[-2:],  # (1024, 1024)
-                        mode="bilinear",
-                        align_corners=False
-                    )  # [B,1,1024,1024]
+                        pred_masks = torch.stack(mask_list, dim=0)
+                        pred_ious = torch.stack(iou_list, dim=0)
 
-                    bce   = F.binary_cross_entropy_with_logits(logit_up, masks)
-                    focal = sigmoid_focal_loss(logit_up, masks, reduction="mean")
+                        best_indices = pred_ious.argmax(dim=1)
+                        sel_masks = pred_masks[
+                            torch.arange(len(pred_masks)), best_indices
+                        ].unsqueeze(1)
 
-                    prob = torch.sigmoid(logit_up)      # [B,1,1024,1024]
-                    num  = (prob * masks).sum((-2, -1)) * 2  # sum over H,W
-                    den  = prob.sum((-2, -1)) + masks.sum((-2, -1))
-                    dice_loss = 1 - (num / (den + 1e-6)).mean()
-                    task_loss = bce + 0.5 * focal + dice_loss
+                        bce = F.binary_cross_entropy_with_logits(sel_masks, masks)
+                        focal = sigmoid_focal_loss(sel_masks, masks, reduction="mean")
+
+                        prob = torch.sigmoid(sel_masks)
+                        num = (prob * masks).sum((-2, -1)) * 2
+                        den = prob.sum((-2, -1)) + masks.sum((-2, -1))
+                        dice_loss = 1 - (num / (den + 1e-6)).mean()
+                        task_loss = bce + 0.5 * focal + dice_loss
+
+                        with torch.no_grad():
+                            gt_bin = masks > 0.5
+                            ious = []
+                            for b in range(pred_masks.shape[0]):
+                                preds_bin = (torch.sigmoid(pred_masks[b]) > 0.5).float()
+                                inter = (preds_bin * gt_bin[b]).sum((-2, -1))
+                                union = preds_bin.sum((-2, -1)) + gt_bin[b].sum((-2, -1)) - inter
+                                ious.append(inter / (union + 1e-6))
+                            gt_ious = torch.stack(ious, dim=0)
+
+                        iou_loss = F.mse_loss(pred_ious, gt_ious)
 
                     dist_loss = torch.tensor(0.0, device=dev)
                     if use_distillation and hook_handles:
@@ -408,15 +439,18 @@ def main():
                                     except Exception as e:
                                         log.debug(f"RKD error: {e}")
 
-                    loss = (task_loss + lambda_coef * dist_loss) / tr_cfg.get("gradient_accumulation", 1)
+                    loss = (task_loss + iou_loss + lambda_coef * dist_loss) / tr_cfg.get(
+                        "gradient_accumulation", 1
+                    )
 
                 scaler.scale(loss).backward()
                 # del low_res_logits, tmp, logit_up, prob, focal, dice_loss
-                if use_distillation and 'feat_student' in locals():
+                if use_distillation and "feat_student" in locals():
                     del feat_student
 
-                if ((step + 1) % tr_cfg.get("gradient_accumulation", 1) == 0
-                   or (step + 1) == len(tr_loader)):
+                if (step + 1) % tr_cfg.get("gradient_accumulation", 1) == 0 or (step + 1) == len(
+                    tr_loader
+                ):
                     scaler.unscale_(opt)
                     torch.nn.utils.clip_grad_norm_(student.parameters(), 1.0)
                     scaler.step(opt)
@@ -428,14 +462,16 @@ def main():
 
                 tot_task += task_loss.item()
                 tot_dist += dist_loss.item()
+                tot_iou += iou_loss.item()
 
                 pbar.set_postfix(
                     bce=f"{bce.item():.3f}",
                     focal=f"{focal.item():.3f}",
                     dice=f"{dice_loss.item():.3f}",
+                    iou=f"{iou_loss.item():.3f}",
                     dist=f"{dist_loss.item():.3f}",
                     total=f"{loss.item():.3f}",
-                    lr=f"{scheduler.get_last_lr()[0]:.2e}"
+                    lr=f"{scheduler.get_last_lr()[0]:.2e}",
                 )
 
                 if step % 100 == 0:
@@ -443,6 +479,7 @@ def main():
 
             writer.add_scalar("train/task_loss", tot_task / len(tr_loader), ep)
             writer.add_scalar("train/dist_loss", tot_dist / len(tr_loader), ep)
+            writer.add_scalar("train/iou_loss", tot_iou / len(tr_loader), ep)
             writer.add_scalar("train/lambda_coef", lambda_coef, ep)
             for i, g in enumerate(opt.param_groups):
                 writer.add_scalar(f"lr/group{i}", g["lr"], ep)
@@ -464,32 +501,46 @@ def main():
                         for i in range(len(imgs)):
                             entry = {
                                 "image": imgs[i],
-                                "original_size": (int(original_sizes[i][0]), int(original_sizes[i][1])),
+                                "original_size": (
+                                    int(original_sizes[i][0]),
+                                    int(original_sizes[i][1]),
+                                ),
                             }
                             if vb["box_prompt"][i] is not None:
                                 entry["boxes"] = vb["box_prompt"][i].to(dev).unsqueeze(0)  # (1,4)
                             if vb["point_coords"][i] is not None:
-                                entry["point_coords"] = vb["point_coords"][i].to(dev).unsqueeze(0)  # (1,K,2)
-                                entry["point_labels"] = vb["point_labels"][i].to(dev).unsqueeze(0)  # (1,K)
+                                entry["point_coords"] = (
+                                    vb["point_coords"][i].to(dev).unsqueeze(0)
+                                )  # (1,K,2)
+                                entry["point_labels"] = (
+                                    vb["point_labels"][i].to(dev).unsqueeze(0)
+                                )  # (1,K)
                             vinp.append(entry)
-                        vo = student(batched_input=vinp, multimask_output=False)
+                        vo = student(batched_input=vinp, multimask_output=True)
 
-                        low_res_list = [o["low_res_logits"].squeeze() for o in vo]
-                        low_res_logits = torch.stack(low_res_list, dim=0)
-                        tmp_val = low_res_logits.unsqueeze(1)
+                        mask_list = []
+                        iou_list = []
+                        for o in vo:
+                            mask_up = F.interpolate(
+                                o["masks"].to(torch.float32),
+                                size=masks.shape[-2:],
+                                mode="bilinear",
+                                align_corners=False,
+                            )
+                            mask_list.append(mask_up)
+                            iou_list.append(o["iou_predictions"].to(torch.float32))
 
-                        low_res_up = F.interpolate(
-                            tmp_val,
-                            size=masks.shape[-2:],
-                            mode="bilinear",
-                            align_corners=False
+                        pred_masks = torch.stack(mask_list, dim=0)
+                        pred_ious = torch.stack(iou_list, dim=0)
+
+                        best_indices = pred_ious.argmax(dim=1)
+                        probs = torch.sigmoid(
+                            pred_masks[torch.arange(len(pred_masks)), best_indices].unsqueeze(1)
                         )
 
-                        probs = torch.sigmoid(low_res_up)  # [B,1,1024,1024]
-
                         for i in range(len(imgs)):
-                            prob_i = probs[i]               # [1,1024,1024]
-                            gt_i   = masks[i]               # [1,1024,1024]
+                            prob_i = probs[i]  # [1,1024,1024]
+                            gt_i = masks[i]  # [1,1024,1024]
 
                             # Soft Dice for loss logging
                             num_soft = (prob_i * gt_i).sum((-2, -1)) * 2
@@ -503,30 +554,38 @@ def main():
                             bin_dice = (num_bin / (den_bin + 1e-6)).item()
 
                             union = pred_bin + gt_i - pred_bin * gt_i
-                            bin_iou = ((pred_bin * gt_i).sum((-2, -1)) / (union.sum((-2, -1)) + 1e-6)).item()
+                            bin_iou = (
+                                (pred_bin * gt_i).sum((-2, -1)) / (union.sum((-2, -1)) + 1e-6)
+                            ).item()
 
                             dices.append(bin_dice)
                             ious.append(bin_iou)
 
                             # 印 debug: 第一張
                             if bi == 0 and i == 0:
-                                log.info(f"[VAL] id={vb['id'][i]}, "
-                                         f"soft_dice={soft_dice:.3f}, "
-                                         f"bin_dice={bin_dice:.3f}, bin_iou={bin_iou:.3f}, "
-                                         f"gt_sum={gt_i.sum().item():.0f}, pred_sum={pred_bin.sum().item():.0f}")
+                                log.info(
+                                    f"[VAL] id={vb['id'][i]}, "
+                                    f"soft_dice={soft_dice:.3f}, "
+                                    f"bin_dice={bin_dice:.3f}, bin_iou={bin_iou:.3f}, "
+                                    f"gt_sum={gt_i.sum().item():.0f}, "
+                                    f"pred_sum={pred_bin.sum().item():.0f}"
+                                )
 
                             # Visualization
                             if (
                                 bi == 0
                                 and cfg["visual"].get("status", False)
-                                and (ep % cfg["visual"].get("save_every_n_epochs", 10) == 0
-                                     or ((np.mean(dices) + np.mean(ious)) / 2) > best_score
+                                and (
+                                    ep % cfg["visual"].get("save_every_n_epochs", 10) == 0
+                                    or ((np.mean(dices) + np.mean(ious)) / 2) > best_score
                                 )
                             ):
                                 cur_path = Path(cfg["visual"]["save_path"]) / f"epoch_{ep}"
                                 cur_path.mkdir(parents=True, exist_ok=True)
-                                img_denorm = imgs[i] * torch.tensor(STD, device=dev)[:, None, None] \
-                                               + torch.tensor(MEAN, device=dev)[:, None, None]
+                                img_denorm = (
+                                    imgs[i] * torch.tensor(STD, device=dev)[:, None, None]
+                                    + torch.tensor(MEAN, device=dev)[:, None, None]
+                                )
                                 img_denorm = img_denorm.clamp(0, 1).cpu()
 
                                 pred_mask = probs[i].squeeze(0).cpu()
@@ -552,7 +611,7 @@ def main():
                                     original_size=None,
                                     threshold=cfg["visual"].get("IOU_threshold", 0.5),
                                     save_dir=str(cur_path),
-                                    filename_info=f"ep{ep}_id{vb['id'][i]}_b{bi}_s{i}"
+                                    filename_info=(f"ep{ep}_id{vb['id'][i]}_b{bi}_s{i}"),
                                 )
                     except Exception as e:
                         log.error(f"Error in validation step {bi}: {e}")
@@ -564,17 +623,30 @@ def main():
                 writer.add_scalar("val/dice", v_dice, ep)
                 writer.add_scalar("val/iou", v_iou, ep)
                 writer.add_scalar("val/score", v_score, ep)
-                log.info(f"Epoch {ep}  Bin-Dice={v_dice:.4f} Bin-IoU={v_iou:.4f} Score={v_score:.4f}")
+                log.info(
+                    (
+                        f"Epoch {ep}  Bin-Dice={v_dice:.4f} "
+                        f"Bin-IoU={v_iou:.4f} Score={v_score:.4f}"
+                    )
+                )
                 log_gpu_memory(f"Epoch {ep} validation completed")
 
-                if use_distillation and dist_cfg.get("dynamic_lambda", {}).get("enable_plateau_scheduler"):
+                if use_distillation and dist_cfg.get("dynamic_lambda", {}).get(
+                    "enable_plateau_scheduler"
+                ):
                     if v_score > best_score + 1e-4:
                         dyn_wait = 0
-                        lambda_coef = min(lambda_coef / dist_cfg["dynamic_lambda"]["factor"], 1.0)
+                        lambda_coef = min(
+                            lambda_coef / dist_cfg["dynamic_lambda"]["factor"],
+                            1.0,
+                        )
                     else:
                         dyn_wait += 1
                         if dyn_wait >= dist_cfg["dynamic_lambda"]["patience"]:
-                            lambda_coef = max(lambda_coef * dist_cfg["dynamic_lambda"]["factor"], 1e-3)
+                            lambda_coef = max(
+                                lambda_coef * dist_cfg["dynamic_lambda"]["factor"],
+                                1e-3,
+                            )
                             dyn_wait = 0
                             log.info(f"λ ↓ {lambda_coef:.3f}")
 


### PR DESCRIPTION
## Summary
- augment bounding box prompts with random jitter
- compute loss on high-res masks and enable IOU head training
- accumulate IOU loss and log during training
- fix mask shape issues and update dependencies

## Testing
- `black -l 100 train.py finetune_utils/datasets.py` *(passed)*
- `flake8 train.py finetune_utils/datasets.py` *(passed)*
- `mypy train.py finetune_utils/datasets.py` *(fails: missing stubs)*


------
https://chatgpt.com/codex/tasks/task_e_6841461da67c83268b6370788e41c9ca