### PR TITLE
Implement segment everything finetune mode

### DIFF
--- a/Segment_Everything_Finetune.md
+++ b/Segment_Everything_Finetune.md
@@ -1,0 +1,48 @@
+# Segment Everything Finetuning
+
+This document outlines the added training mode for finetuning MobileSAM when the
+target task is **segment everything**.  The approach mimics the behaviour of
+`SamAutomaticMaskGenerator` by providing grid based prompts and supervising all
+objects within an image simultaneously.
+
+## Dataset
+- Use the same folder structure as the original dataset:
+  ```
+  dataset/
+    image/xxx.jpg
+    mask/xxx/obj_0.png
+    mask/xxx/obj_1.png
+  ```
+- For each image all object masks under `mask/<id>/` are loaded and stacked.
+- A regular point grid is generated over the original image (default step
+  size = 32 px).  Points are scaled to the network resolution (1024×1024).
+
+## Training Changes
+- New dataset class **`SegmentEverythingDataset`** provides the stacked ground
+  truth masks and the grid prompts.
+- When `dataset.mode` in the config is set to `"everything"` the training script
+  switches to this dataset and calls a custom prediction routine that evaluates a
+  batch of grid prompts for every image.
+- Each grid point produces three candidate masks (`multimask_output=True`).  For
+  every candidate the IoU with each ground truth mask is computed.  If the best
+  IoU is larger than 0.8 the candidate is matched to that object, otherwise it is
+  treated as background.
+- Loss per candidate = **BCE + 0.5·Focal + Dice**.  The IoU prediction head is
+  supervised with MSE against the measured IoU.
+- For unmatched ground truth masks the candidate with highest IoU is also used
+  for supervision.
+- Distillation losses are disabled in this mode for simplicity, but the rest of
+  the training pipeline (optimizer, scheduler, etc.) remains unchanged.
+
+## Usage
+In `configs/mobileSAM.json` set
+```json
+"dataset": {
+  "mode": "everything",
+  "grid_points": 32,
+  "train_dataset": "./datasets/train",
+  "val_dataset": "./datasets/val"
+}
+```
+Running `python train.py --config configs/mobileSAM.json` will finetune MobileSAM
+with segment-everything supervision.

--- a/configs/mobileSAM_se.json
+++ b/configs/mobileSAM_se.json
@@ -1,0 +1,91 @@
+{
+  "dataset": {
+    "train_dataset": "./datasets/train",
+    "val_dataset": "./datasets/val",
+    "max_bbox_shift": 20,
+    "num_workers": 4,
+    "prompt_mode": "mixed",
+    "min_points": 1,
+    "max_points": 3,
+    "mode": "everything",
+    "grid_points": 16
+  },
+  "model": {
+    "checkpoint_path": "./weights/mobile_sam.pt",
+    "type": "vit_t",
+    "image_size": 1024,
+    "save_path": "./logs"
+  },
+  "train": {
+    "epochs": 3,
+    "lr": 0.00001,
+    "batch_size": 2,
+    "val_freq": 1,
+    "gradient_accumulation": 1,
+    "bf16": true,
+    "warmup_step": 250,
+    "min_lr_ratio": 0.0,
+    "resume": false,
+    "early_stop_patience": 20
+  },
+  "visual": {
+    "status": true,
+    "save_path": "./images",
+    "IOU_threshold": 0.5,
+    "save_every_n_epochs": 10
+  },
+  "freeze": {
+    "freeze_image_encoder": false,
+    "freeze_prompt_encoder": false,
+    "freeze_mask_decoder": false,
+    "unfreeze_epoch": 10
+  },
+  "distillation": {
+    "enable": true,
+    "use_precomputed_features": true,
+    "precomputed_root": "precomputed",
+    "encoder_matching": {
+      "enable": true,
+      "lambda_mse": 1.0,
+      "lambda_kl": 1.0,
+      "temperature": 2.0
+    },
+    "decoder_matching": {
+      "enable": true,
+      "lambda_mse": 1.0,
+      "lambda_cos": 1.0,
+      "lambda_kl": 1.0,
+      "temperature": 2.0
+    },
+    "attention_matching": {
+      "enable": true,
+      "lambda": 1.0,
+      "temperature": 0.5
+    },
+    "relational_KD": {
+      "enable": true,
+      "lambda": 1.0,
+      "dist_factor": 1.0,
+      "angle_factor": 2.0
+    },
+    "dynamic_lambda": {
+      "enable_plateau_scheduler": true,
+      "patience": 5,
+      "factor": 0.5
+    }
+  },
+  "teachers": [
+    {
+      "name": "SAM-H",
+      "cfg": "configs/sam_h.yaml",
+      "checkpoint": "weights/sam_vit_h_4b8939.pth",
+      "weight": 0.5
+    },
+    {
+      "name": "MobileSAM_orig",
+      "cfg": "configs/mobile_sam_orig.yaml",
+      "checkpoint": "weights/mobile_sam.pt",
+      "weight": 0.5
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add SegmentEverythingDataset for grid prompt training
- support new dataset mode in train script
- include helper to run model on grid points
- document the approach in Segment_Everything_Finetune.md
- provide an example config for the new mode

## Testing
- `bash linter.sh` *(fails: Found 40 errors in 14 files)*
- `python train.py --config configs/mobileSAM_se.json` *(failed to complete; process killed)*

------
https://chatgpt.com/codex/tasks/task_e_6846bf4390f88326a7015ed17f458918