### PR TITLE
Fix mask scaling for MobileSAM finetuning

### DIFF
--- a/Finetune_Seg_Everything.md
+++ b/Finetune_Seg_Everything.md
@@ -24,6 +24,7 @@ dataset/
 2. **Prediction** — for every grid point the model predicts three candidate masks (`multimask_output=True`).
 3. **Matching** — the IoU of each candidate against every ground-truth mask is computed and a Hungarian assignment selects the best one-to-one pairs.  Assigned pairs with IoU ≥ `0.5` are treated as foreground while the rest are background.
 4. **Loss**
+   - Masks are downsampled to 256×256 so that loss is computed directly on the decoder's low resolution logits.
    - For each candidate: `BCE * w_bce + Focal * w_focal + Dice * w_dice`.
    - IoU prediction is supervised with MSE (`w_iou`).
    - Classification: every candidate is labelled as foreground or background. The

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Finetuning is primarily controlled by `train.py` and configured using a JSON fil
 The finetuning script expects datasets in a simple image-mask pair format:
 * **Images:** Standard image files (e.g., JPG, PNG).
 * **Masks:** Grayscale or binary image files where each pixel value represents a class or a binary segmentation. The `SAMDataset` in `finetune_utils/datasets.py` loads these masks and converts them to binary format if necessary (values > 0 become 1).
-* The `SAMDataset` class handles loading images and masks, applying transformations (resizing, normalization), and generating bounding box prompts from the ground truth masks. These bounding boxes are then used as prompts during training.
+* The `SAMDataset` class handles loading images and masks, applying transformations (resizing, normalization), and generating bounding box or point prompts from the ground truth masks.
+* Masks are first resized using `ResizeLongestSide` and padded to a square matching the model's input size (1024×1024 by default). For training the mask decoder directly, the ground truth masks are further downsampled to 1/4 of this resolution (256×256) so the loss can be computed on the decoder's low resolution logits.
+* During validation and visualization all predicted masks are upsampled back to the original image size using the model's built‑in `postprocess_masks` to ensure proper pixel alignment.
 
 ### Training Script
 

--- a/app/app.py
+++ b/app/app.py
@@ -1,9 +1,10 @@
-import os
-
-import gradio as gr
 import numpy as np
 import torch
+
 from mobile_sam import SamAutomaticMaskGenerator, SamPredictor, sam_model_registry
+
+import gradio as gr
+import os
 from PIL import ImageDraw
 from utils.tools import box_prompt, format_results, point_prompt
 from utils.tools_gradio import fast_process
@@ -28,10 +29,10 @@ title = "<center><strong><font size='8'>Faster Segment Anything(MobileSAM)<font>
 
 description_e = """This is a demo of [Faster Segment Anything(MobileSAM) Model](https://github.com/ChaoningZhang/MobileSAM).
 
-                   We will provide box mode soon. 
+                   We will provide box mode soon.
 
                    Enjoy!
-                
+
               """
 
 description_p = """ # Instructions for point mode
@@ -110,9 +111,7 @@ def segment_with_points(
     new_h = int(h * scale)
     image = image.resize((new_w, new_h))
 
-    scaled_points = np.array(
-        [[int(x * scale) for x in point] for point in global_points]
-    )
+    scaled_points = np.array([[int(x * scale) for x in point] for point in global_points])
     scaled_point_label = np.array(global_point_label)
 
     if scaled_points.size == 0 and scaled_point_label.size == 0:
@@ -132,9 +131,7 @@ def segment_with_points(
 
     results = format_results(masks, scores, logits, 0)
 
-    annotations, _ = point_prompt(
-        results, scaled_points, scaled_point_label, new_h, new_w
-    )
+    annotations, _ = point_prompt(results, scaled_points, scaled_point_label, new_h, new_w)
     annotations = np.array([annotations])
 
     fig = fast_process(
@@ -183,9 +180,7 @@ cond_img_e = gr.Image(label="Input", value=default_example[0], type="pil")
 cond_img_p = gr.Image(label="Input with points", value=default_example[0], type="pil")
 
 segm_img_e = gr.Image(label="Segmented Image", interactive=False, type="pil")
-segm_img_p = gr.Image(
-    label="Segmented Image with points", interactive=False, type="pil"
-)
+segm_img_p = gr.Image(label="Segmented Image with points", interactive=False, type="pil")
 
 global_points = []
 global_point_label = []
@@ -279,9 +274,7 @@ with gr.Blocks(css=css, title="Faster Segment Anything(MobileSAM)") as demo:
                     )
 
                     with gr.Column():
-                        segment_btn_p = gr.Button(
-                            "Start segmenting!", variant="primary"
-                        )
+                        segment_btn_p = gr.Button("Start segmenting!", variant="primary")
                         clear_btn_p = gr.Button("Restart", variant="secondary")
 
                 gr.Markdown("Try some of the examples below ⬇️")
@@ -312,9 +305,7 @@ with gr.Blocks(css=css, title="Faster Segment Anything(MobileSAM)") as demo:
     #     outputs=segm_img_e,
     # )
 
-    segment_btn_p.click(
-        segment_with_points, inputs=[cond_img_p], outputs=[segm_img_p, cond_img_p]
-    )
+    segment_btn_p.click(segment_with_points, inputs=[cond_img_p], outputs=[segm_img_p, cond_img_p])
 
     def clear():
         return None, None


### PR DESCRIPTION
## Summary
- return downsampled masks and raw masks in dataset
- compute losses using low-res logits
- match validation and visualisation with original image size
- document new mask processing steps
- fix device placement for original masks during training/validation
- resize masks and points in visualisations
- fix dice loss broadcast error during box prompt training

## Testing
- `bash linter.sh` *(fails: mypy reports missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_685259eff9d883268647a882ac2aefec