### PR TITLE
Improve eval_amg logging

### DIFF
--- a/configs/eval_local.yaml
+++ b/configs/eval_local.yaml
@@ -1,0 +1,12 @@
+model_type: vit_t
+output_csv: results/eval.csv
+viz_dir: results/visuals
+weights:
+  - name: run1
+    path: weights/mobile_sam.pt
+  - name: run2
+    path: weights/mobile_sam.pt
+datasets:
+  - name: val
+    image_dir: datasets/val/image
+    mask_dir: datasets/val/mask


### PR DESCRIPTION
## Summary
- add GPU memory logging to help debug out-of-memory kills
- save overlays to temporary directory to avoid RAM growth
- provide a local evaluation example config using bundled weights

## Testing
- `bash linter.sh` *(fails: mypy missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7cffa90832699ae207cd5e8d143